### PR TITLE
Upgrade Gradle Wrapper to 7.0 in 00-minimal

### DIFF
--- a/00-minimal/gradle/wrapper/gradle-wrapper.properties
+++ b/00-minimal/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project  in 00-minimal
from 6.8.3 to 7.0.                       