### PR TITLE
Upgrade Gradle Wrapper to 7.1 in 04-junit

### DIFF
--- a/04-junit/gradle/wrapper/gradle-wrapper.properties
+++ b/04-junit/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project  in 04-junit
from 7.0.2 to 7.1.                       