### PR TITLE
Upgrade Gradle Wrapper to 7.2 in 01-dependencies

### DIFF
--- a/01-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/01-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project  in 01-dependencies
from 7.1.1 to 7.2.                       